### PR TITLE
Testing socket with delay

### DIFF
--- a/common/src/test/kotlin/org/quizfight/common/ConnectionTest.kt
+++ b/common/src/test/kotlin/org/quizfight/common/ConnectionTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.quizfight.common.messages.Message
+import org.quizfight.common.test.DelayedSocket
 import java.net.ServerSocket
 import java.net.Socket
 import java.time.Duration
@@ -23,13 +24,13 @@ class ConnectionTest {
         // Make sure server is available before Client tries to connect
         val serverSocket = ServerSocket(0)
         val job = GlobalScope.launch {
-            val outgoing = SocketConnection(serverSocket.accept(), emptyMap())
+            val outgoing = SocketConnection(DelayedSocket(serverSocket.accept()), emptyMap())
             outgoing.send(StringMessage(testValue))
             outgoing.close()
             serverSocket.close()
         }
 
-        val clientSocket = Socket("localhost", serverSocket.localPort)
+        val clientSocket = DelayedSocket(Socket("localhost", serverSocket.localPort))
         SocketConnection(clientSocket, mapOf(
             StringMessage::class to { conn, msg ->
                 Assertions.assertTrue(msg is StringMessage)

--- a/common/src/test/kotlin/org/quizfight/common/test/DelayedSocket.kt
+++ b/common/src/test/kotlin/org/quizfight/common/test/DelayedSocket.kt
@@ -1,0 +1,28 @@
+package org.quizfight.common.test
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.Socket
+import kotlin.random.Random
+
+class DelayedSocket(private val socket: Socket) : Socket() {
+    private val outStream = socket.getOutputStream()
+    private val inStream  = socket.getInputStream()
+
+    private val outWrapper = object : OutputStream() {
+        override fun write(b: Int) {
+            Thread.sleep(Random.nextLong(1, 5))
+            outStream.write(b)
+        }
+    }
+    private val inWrapper = object : InputStream() {
+        override fun read(): Int {
+            Thread.sleep(Random.nextLong(1, 5))
+            return inStream.read()
+        }
+    }
+
+    override fun getOutputStream() = outWrapper
+    override fun getInputStream() = inWrapper
+    override fun close() = socket.close()
+}


### PR DESCRIPTION
This adds a socket decorator that adds a delay of 1-5ms when reading or writing. This is even slower than a GPRS networking connection, but if our code works with this, then it should work with every real life delay, too.

The decorator currently only supports the following methods:
- getOutputStream()
- getInputStream()
- close()

This is because it needs to be a decorator for existing and connected Sockets returned by `ServerSocket.accept()`, but also needs to inherit from Socket which has no suitable interface. Other methods of Socket have for now been left out for the sake of brevitiy but can and should be added later when necessary.