### PR TITLE
Refactor frontend networking

### DIFF
--- a/app/src/main/java/org/quizfight/quizfight/AllGamesActivity.kt
+++ b/app/src/main/java/org/quizfight/quizfight/AllGamesActivity.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.quizfight.common.messages.GameData
+import org.quizfight.common.messages.MsgGameList
 import org.quizfight.common.messages.MsgRequestOpenGames
 
 /**
@@ -19,7 +20,6 @@ import org.quizfight.common.messages.MsgRequestOpenGames
  * @author Aude Nana
  */
 class AllGamesActivity : CoroutineScope, AppCompatActivity() {
-
     private var job = Job()
     override val coroutineContext = Dispatchers.Main + job
 
@@ -30,7 +30,10 @@ class AllGamesActivity : CoroutineScope, AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_all_games)
 
-        sendRequestOpenGame()
+        Client.withHandlers(mapOf(
+            MsgGameList::class to { _, msg -> showGames((msg as MsgGameList).games) }
+        ))
+        Client.send(MsgRequestOpenGames())
 
         // Set an item click listener for ListView
         all_games_container.onItemClickListener = AdapterView.OnItemClickListener { parent, view, position, id ->
@@ -49,25 +52,14 @@ class AllGamesActivity : CoroutineScope, AppCompatActivity() {
         }
 
         btn_sync.setOnClickListener {
-            sendRequestOpenGame()
+            Client.send(MsgRequestOpenGames())
         }
-
-
-    }
-
-    fun sendRequestOpenGame(){
-        launch(Dispatchers.IO) {
-            val client = Client("10.0.2.2", 34567, this@AllGamesActivity)
-            client.conn.send(MsgRequestOpenGames())
-        }
-
     }
 
     /**
      * Displays all available games
      */
     fun showGames(gameList: List<GameData>) = launch {
-
         if(gameList.isEmpty()){
             all_games_container.visibility = View.INVISIBLE
         } else {
@@ -94,5 +86,4 @@ class AllGamesActivity : CoroutineScope, AppCompatActivity() {
         super.onDestroy()
         job.cancel()
     }
-
 }

--- a/app/src/main/java/org/quizfight/quizfight/Client.kt
+++ b/app/src/main/java/org/quizfight/quizfight/Client.kt
@@ -1,66 +1,41 @@
 package org.quizfight.quizfight
 
 import android.support.v7.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.quizfight.common.Connection
 import org.quizfight.common.SocketConnection
-import org.quizfight.common.messages.MsgGameInfo
-import org.quizfight.common.messages.MsgGameList
-import org.quizfight.common.messages.MsgQuestion
-import org.quizfight.common.messages.MsgStartGame
+import org.quizfight.common.messages.*
 import org.quizfight.common.question.ChoiceQuestion
 import java.net.Socket
+import kotlin.coroutines.CoroutineContext
+import kotlin.reflect.KClass
 
-class Client(serverIp: String, port: Int , activity: AppCompatActivity) {
+const val masterServerIP = "10.0.0.2"
+const val masterServerPort = 34567
 
-    val socket = Socket(serverIp, port)
-    val conn : SocketConnection
-    val activity = activity
+object Client : CoroutineScope, Connection {
+    override val coroutineContext = Dispatchers.Main
+    private var connection: Connection? = null
 
     init {
-        conn = SocketConnection(socket,
-                mapOf( MsgQuestion ::class to { conn, msg -> receiveQuestion(msg as MsgQuestion )},
-                        MsgGameInfo ::class to { conn, msg -> receiveGameInfo(msg as MsgGameInfo )},
-                        MsgGameList ::class to { conn, msg -> receiveGameList(msg as MsgGameList )},
-                        MsgStartGame ::class to { conn, msg -> receiveGameStart(msg as MsgStartGame )}
-                ))
-
-    }
-
-    fun receiveQuestion(msg :MsgQuestion){
-        if(activity is QuizActivity) {
-            var question: ChoiceQuestion = msg.question as ChoiceQuestion
-            activity.showNextQuestion(question)
-            Thread.sleep(20000)
-            activity.sendScore()
-            //MsgRanking anzeigen bevor nextQuestion anzeigen
-        }
-
-    }
-
-    fun receiveGameInfo(msg: MsgGameInfo){
-        if(activity is CreateGameActivity) {
-            activity.showAttemptQuizStartActivity(msg)
+        launch(Dispatchers.IO) {
+            val socket = Socket(masterServerIP, masterServerPort)
+            connection = SocketConnection(socket, emptyMap())
         }
     }
 
-    fun receiveGameList(msg: MsgGameList){
-        if(activity is AllGamesActivity){
-            activity.showGames(msg.games)
-        }
+    val connected: Boolean
+        get() = connection != null
+
+    override fun send(msg: Message) { launch(Dispatchers.IO) { connection?.send(msg) } }
+    override fun close() { launch(Dispatchers.IO) { connection?.close() } }
+    override fun withHandlers(handlers: Map<KClass<*>, (Connection, Message) -> Unit>): Connection {
+        launch(Dispatchers.IO) { connection?.withHandlers(handlers) }
+        return this
     }
-
-    fun receiveGameStart(msg: MsgStartGame) {
-        if (activity is AttemptQuizStartActivity) {
-            activity.showQuizActivity()
-        }
-
-
-        fun receivePlayerCount() {
-
-            /* MsgGetPlayersCount(val gameId:Int)
-        MsgPlayersCount(val gameId:Int, count: Int)*/
-        }
-
-    }
-
+    override var handlers = connection!!.handlers
+    override val id = connection!!.id
 }
 

--- a/app/src/main/java/org/quizfight/quizfight/CreateGameActivity.kt
+++ b/app/src/main/java/org/quizfight/quizfight/CreateGameActivity.kt
@@ -1,10 +1,12 @@
 package org.quizfight.quizfight
 
+import android.app.Application
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 
 import android.content.Intent
 import android.text.TextUtils
+import android.util.Log
 import android.view.View
 import kotlinx.android.synthetic.main.activity_create_game.*
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/org/quizfight/quizfight/CreateGameActivity.kt
+++ b/app/src/main/java/org/quizfight/quizfight/CreateGameActivity.kt
@@ -81,16 +81,10 @@ class CreateGameActivity : CoroutineScope, AppCompatActivity() {
 
             val gameRequest = GameRequest(gameName, maxPlayer, questionCount)
             //create Game in Backend
-            sendMsgCreateGameToServer(gameRequest,nickname )
-        }
-    }
-
-
-    fun sendMsgCreateGameToServer(gameRequest: GameRequest, nickname: String){
-        // Use launch(Dispatchers.IO){} for networking operations
-        launch(Dispatchers.IO) {
-            client = Client("10.0.2.2", 34567, this@CreateGameActivity)
-            client.conn.send(MsgCreateGame(gameRequest,nickname))
+            Client.withHandlers(mapOf(
+                MsgGameInfo::class to { _, msg -> showAttemptQuizStartActivity(msg as MsgGameInfo) }
+            ))
+            Client.send(MsgCreateGame(gameRequest, nickname))
         }
     }
 

--- a/app/src/main/java/org/quizfight/quizfight/GameDetailActivity.kt
+++ b/app/src/main/java/org/quizfight/quizfight/GameDetailActivity.kt
@@ -93,7 +93,7 @@ class GameDetailActivity : CoroutineScope, AppCompatActivity() {
             nickname = editText.text.toString()
             if(!nickname.isNullOrBlank()) {
                 nicknameEntered = true
-                sendJoinMessage()
+                Client.send(MsgJoin(gameId, nickname))
                 showAttemptQuizStart()
             } else {
                 displayAlert()
@@ -101,13 +101,5 @@ class GameDetailActivity : CoroutineScope, AppCompatActivity() {
         }
 
         builder.create().show()
-    }
-
-    fun sendJoinMessage() {
-        launch(Dispatchers.IO) {
-            val client = Client("192.168.2.100", 34567, this@GameDetailActivity)
-            client.conn.send(MsgJoin(gameId, nickname))
-
-        }
     }
 }

--- a/app/src/main/java/org/quizfight/quizfight/QuizActivity.kt
+++ b/app/src/main/java/org/quizfight/quizfight/QuizActivity.kt
@@ -24,7 +24,6 @@ class QuizActivity : CoroutineScope, AppCompatActivity() {
 
     private lateinit var currentQuestion: ChoiceQuestion
     private var answerSelected : Boolean = false
-    private lateinit var client : Client
 
     //Countdown Timer
     val millisInFuture: Long = 21000 // for 20 seconds plus 1 second imprecision
@@ -36,13 +35,6 @@ class QuizActivity : CoroutineScope, AppCompatActivity() {
 
         //sollte auch vom Server gelesen werden
         questionCountTotal = intent.getIntExtra("questionCountTotal", 4)
-
-        // Use launch(Dispatchers.IO){} for networking operations
-        launch(Dispatchers.IO) {
-            client = Client("10.0.2.2", 34567, this@QuizActivity)
-
-        }
-
     }
 
     override fun onDestroy() {
@@ -100,9 +92,7 @@ class QuizActivity : CoroutineScope, AppCompatActivity() {
             answer = selectedButton.text.toString()
         }
 
-        launch(Dispatchers.Default){
-            client.conn.send(MsgScore(currentQuestion.evaluate(answer.toString())))
-        }
+        Client.send(MsgScore(currentQuestion.evaluate(answer)))
 
         answerSelected = false
     }

--- a/app/src/main/java/org/quizfight/quizfight/StartActivity.kt
+++ b/app/src/main/java/org/quizfight/quizfight/StartActivity.kt
@@ -6,10 +6,15 @@ import android.os.Bundle
 import android.view.View
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.quizfight.common.SocketConnection
 import org.quizfight.common.Connection
 import java.net.Socket
+import android.widget.Toast
+import android.R.attr.data
+import android.util.Log
+
 
 /**
  * This activity is the first activity of the app
@@ -20,6 +25,11 @@ class StartActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_start)
+
+        GlobalScope.launch(Dispatchers.IO) {
+            while (!Client.connected);
+            Log.d("Connection", "Client connected to master server")
+        }
     }
 
     /**

--- a/app/src/main/java/org/quizfight/quizfight/StartActivity.kt
+++ b/app/src/main/java/org/quizfight/quizfight/StartActivity.kt
@@ -4,6 +4,12 @@ import android.content.Intent
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.quizfight.common.SocketConnection
+import org.quizfight.common.Connection
+import java.net.Socket
 
 /**
  * This activity is the first activity of the app
@@ -11,11 +17,8 @@ import android.view.View
  * @author Aude Nana
  */
 class StartActivity : AppCompatActivity() {
-
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         setContentView(R.layout.activity_start)
     }
 
@@ -26,7 +29,6 @@ class StartActivity : AppCompatActivity() {
     fun showAllGamesActivity(view: View) {
         val intent = Intent(this, AllGamesActivity::class.java)
         startActivity(intent)
-
     }
 
     /**
@@ -36,7 +38,5 @@ class StartActivity : AppCompatActivity() {
     fun showCreateGameActivity(view: View) {
         val intent = Intent(this, CreateGameActivity::class.java)
         startActivity(intent)
-
     }
-
 }


### PR DESCRIPTION
- Changes Client class to a object declaration (basically a singleton) that implements the Connection interface
  - Singletons are imo an anti-pattern, however, passing the connection through intents needs serialization which doesn't work with sockets
  - Another alternative would be a custom Application class, which would have been just a wrapper for the singleton and added unnecessary complexity
  - The cleanest alternative would be a so called service, from quick look at the docs it sounded way too overkill and complex for what we're trying to do though
  - We could also let the Client get created through a factory for testability if necessary
- Added coroutine wrappers so UI activities shouldn't need to handle that
- Removed reinstantiation of the connection in every activity - Client handles everything

TODO:
- [x] Check and fix what broke
- [x] Remember last message and handle server transfers autonomously in Client
- [x] ~Let user wait until `Client.connected == true` (disabled buttons or a loading screen would be nice)~
  Not part of refactor